### PR TITLE
fix: adjust frontend Docker build context and path for API generation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,8 @@ services:
 
   frontend:
     build:
-      context: ./frontend
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: frontend/Dockerfile
     container_name: frontend
     expose:
       - "80"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,7 +11,6 @@ WORKDIR /app/frontend
 COPY frontend/package*.json .
 RUN npm ci
 RUN npm run generate:api
-COPY . .
 RUN npm run build
 RUN npm prune --production
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,7 +8,6 @@ COPY frontend ./frontend
 COPY api ./api
 WORKDIR /app/frontend
 
-COPY frontend/package*.json .
 RUN npm ci
 RUN npm run generate:api
 RUN npm run build

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,15 +4,20 @@
 # build stage
 FROM node:20-alpine AS builder
 WORKDIR /app
-COPY package*.json .
+COPY frontend ./frontend
+COPY api ./api
+WORKDIR /app/frontend
+
+COPY frontend/package*.json .
 RUN npm ci
+RUN npm run generate:api
 COPY . .
 RUN npm run build
 RUN npm prune --production
 
 # runtime stage (Static server)
 FROM nginx:alpine
-COPY --from=builder /app/build /usr/share/nginx/html
+COPY --from=builder /app/frontend/build /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]
 


### PR DESCRIPTION
- Changed Docker build context for frontend from ./frontend to repository root
- Updated Dockerfile to correctly locate and copy API config files
- Ensured API clients are generated during the build process
- Fixed build output path (/app/frontend/build)